### PR TITLE
Clarify versioning with Docker in README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get -y install\
         python3-pip \
 	curl
 
-# install the required solc vesion
+# install the required solc version
 RUN curl -L https://github.com/ethereum/solidity/releases/download/v$SOLC/solc-static-linux > /usr/bin/solc-$SOLC && \
     chmod +x /usr/bin/solc-$SOLC && \
     ln -s /usr/bin/solc-$SOLC /usr/local/bin/solc

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is the successor of the popular Securify security scanner (you can find the o
 
 Features
 ===
-- Supports 38 vulnerabilities (see [table](#supported-vulnerabilities) below)
+- Supports 37 vulnerabilities (see [table](#supported-vulnerabilities) below)
 - Implements novel context-sensitive static analysis written in Datalog
 - Analyzes contracts written in Solidity >= 0.5.8
 
@@ -31,6 +31,8 @@ To run the container:
 ````angular2
 sudo docker run -it -v <contract-dir-full-path>:/share securify /share/<contract>.sol
 ````
+Note: to run the code via Docker with a Solidity version that is different than `0.5.12`, you will need to modify the variable `ARG SOLC=0.5.12` at the top of the `Dockerfile` to point to your version. After building with the correct version, you should not run into errors.
+
 
 
 Install


### PR DESCRIPTION
1. Resolves misspelling
2. Clarifies how to use a certain version of Solidity by modifying your Dockerfile
3. Changed supported vulnerability number to 37 instead of 38 since that's what the table and all other references say