### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/tests/solidity/public_contracts/DaiHard.sol
+++ b/tests/solidity/public_contracts/DaiHard.sol
@@ -506,7 +506,7 @@ contract DAIHardTrade {
         }
 
         changePhase(Phase.Committed);
-        emit Committed(responder, commPubkey);
+        emit Committed(_responder, commPubkey);
 
         require(daiContract.transferFrom(msg.sender, address(this), getResponderDeposit()),
                                          "Can't transfer the required deposit from the DAI contract. Did you call approve first?"

--- a/tests/solidity/public_contracts/DarknodePayment.flat.sol
+++ b/tests/solidity/public_contracts/DarknodePayment.flat.sol
@@ -1685,7 +1685,7 @@ contract DarknodeRegistry is Claimable, CanReclaimTokens {
         require(address(_darknodePayment) != address(0x0), "DarknodeRegistry: invalid Darknode Payment address");
         IDarknodePayment previousDarknodePayment = darknodePayment;
         darknodePayment = _darknodePayment;
-        emit LogDarknodePaymentUpdated(previousDarknodePayment, darknodePayment);
+        emit LogDarknodePaymentUpdated(previousDarknodePayment, _darknodePayment);
     }
 
     /// @notice Allows the contract owner to update the minimum bond.
@@ -2179,7 +2179,7 @@ contract DarknodePayment is Claimable {
         require(address(_darknodeRegistry) != address(0x0), "DarknodePayment: invalid Darknode Registry address");
         DarknodeRegistry previousDarknodeRegistry = darknodeRegistry;
         darknodeRegistry = _darknodeRegistry;
-        emit LogDarknodeRegistryUpdated(previousDarknodeRegistry, darknodeRegistry);
+        emit LogDarknodeRegistryUpdated(previousDarknodeRegistry, _darknodeRegistry);
     }
 
     /// @notice Transfers the funds allocated to the darknode to the darknode
@@ -2328,7 +2328,7 @@ contract DarknodePayment is Claimable {
     function updatePayoutPercentage(uint256 _percent) external onlyOwner validPercent(_percent) {
         uint256 oldPayoutPercent = nextCyclePayoutPercent;
         nextCyclePayoutPercent = _percent;
-        emit LogPayoutPercentChanged(nextCyclePayoutPercent, oldPayoutPercent);
+        emit LogPayoutPercentChanged(_percent, oldPayoutPercent);
     }
 
     /// @notice Allows the contract owner to initiate an ownership transfer of

--- a/tests/solidity/test_real_contracts/ConditionalEscrow.sol
+++ b/tests/solidity/test_real_contracts/ConditionalEscrow.sol
@@ -105,7 +105,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/ConditionalEscrowMock.sol
+++ b/tests/solidity/test_real_contracts/ConditionalEscrowMock.sol
@@ -105,7 +105,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/Escrow.sol
+++ b/tests/solidity/test_real_contracts/Escrow.sol
@@ -105,7 +105,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/PullPayment.sol
+++ b/tests/solidity/test_real_contracts/PullPayment.sol
@@ -105,7 +105,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/PullPaymentMock.sol
+++ b/tests/solidity/test_real_contracts/PullPaymentMock.sol
@@ -105,7 +105,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/RefundEscrow.sol
+++ b/tests/solidity/test_real_contracts/RefundEscrow.sol
@@ -105,7 +105,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/RefundableCrowdsale.sol
+++ b/tests/solidity/test_real_contracts/RefundableCrowdsale.sol
@@ -580,7 +580,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/RefundableCrowdsaleImpl.sol
+++ b/tests/solidity/test_real_contracts/RefundableCrowdsaleImpl.sol
@@ -580,7 +580,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/RefundablePostDeliveryCrowdsale.sol
+++ b/tests/solidity/test_real_contracts/RefundablePostDeliveryCrowdsale.sol
@@ -580,7 +580,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/RefundablePostDeliveryCrowdsaleImpl.sol
+++ b/tests/solidity/test_real_contracts/RefundablePostDeliveryCrowdsaleImpl.sol
@@ -580,7 +580,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/SampleCrowdsale.sol
+++ b/tests/solidity/test_real_contracts/SampleCrowdsale.sol
@@ -624,7 +624,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 

--- a/tests/solidity/test_real_contracts/Secondary.sol
+++ b/tests/solidity/test_real_contracts/Secondary.sol
@@ -41,6 +41,6 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }

--- a/tests/solidity/test_real_contracts/SecondaryMock.sol
+++ b/tests/solidity/test_real_contracts/SecondaryMock.sol
@@ -41,7 +41,7 @@ contract Secondary {
     function transferPrimary(address recipient) public onlyPrimary {
         require(recipient != address(0));
         _primary = recipient;
-        emit PrimaryTransferred(_primary);
+        emit PrimaryTransferred(recipient);
     }
 }
 


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.